### PR TITLE
Create view.html.twig

### DIFF
--- a/src/BM2/SiteBundle/Resources/views/Realm/view.html.twig
+++ b/src/BM2/SiteBundle/Resources/views/Realm/view.html.twig
@@ -18,7 +18,7 @@
 </div>
 
 <div style="float:right">
-	&nbsp;<ul id="loadlist" class="shortlist" style="display:inline"></ul>
+{#	&nbsp;<ul id="loadlist" class="shortlist" style="display:inline"></ul> #}
 	<div id="map" style="min-width:30em;min-height:30em;margin-left:2em"></div>
 </div>
 <div id="sd_anchor" style="margin-right:1em;height:30em;float:right"></div>


### PR DESCRIPTION
Commenting out loadlist for the map because it's not important to this page to know what's loaded or not, and it improves display on smaller screens if space isn't eaten up by this.