### PR TITLE
Updated WarController.php to fix wealth looting

### DIFF
--- a/src/BM2/SiteBundle/Controller/WarController.php
+++ b/src/BM2/SiteBundle/Controller/WarController.php
@@ -416,9 +416,10 @@ class WarController extends Controller {
 	 						$steal = rand(0, ceil($settlement->getGold() * $ratio));
 							$drop = ceil(rand(40,60) * $settlement->getGold() / 100);
  						}
- 						$result['gold'] = ceil($steal * 0.75); // your soldiers will pocket some (and we just want to make it less effective)
- 						$character->setGold($character->getGold() + $steal);
- 						$settlement->setGold($settlement->getGold() - $drop);
+						$steal = ceil($steal * 0.75); // your soldiers will pocket some (and we just want to make it less effective)
+ 						$result['gold'] = $steal; // send result to page for display
+ 						$character->setGold($character->getGold() + $steal); //add gold to characters purse
+ 						$settlement->setGold($settlement->getGold() - $drop); //remove gold from settlement ?Why do we remove a different amount of gold from the settlement?
  						break;
 					case 'burn':
 						$targets = min(5, floor(sqrt($my_soldiers/5)));


### PR DESCRIPTION
Wealth looting was displaying one value for the amount of gold stolen, but storing a different value. Bug was we were displaying a value 0.75 of the stolen amount to account for "losses to soldiers" but not updating the amount that is sent to the character.

Fixed to store the lesser value in the database