### PR TITLE
Resolve Duplicate Events Each Turn

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
         "sensio/framework-extra-bundle": "~3.0,>=3.0.2",
         "incenteev/composer-parameter-handler": "~2.0",
 
-        "doctrine/doctrine-fixtures-bundle": "dev-master",
-        "friendsofsymfony/user-bundle": "~2.0@dev",
+        "doctrine/doctrine-fixtures-bundle": "2.*",
+        "friendsofsymfony/user-bundle": "~2.0",
         "creof/doctrine2-spatial": "dev-master",
         "knplabs/knp-markdown-bundle": "1.4.*@dev",
         "codeception/codeception": "*",

--- a/src/BM2/SiteBundle/Controller/AccountController.php
+++ b/src/BM2/SiteBundle/Controller/AccountController.php
@@ -584,7 +584,7 @@ class AccountController extends Controller {
 		if ($character->isAlive()) {
 			$character->setLastAccess(new \DateTime("now"));
 			$character->setSlumbering(false);
-			if ($character->getSystem('procd_inactive') {
+			if ($character->getSystem() == 'procd_inactive') {
 				$character->setSystem(NULL);
 			}
 			$em->flush();

--- a/src/BM2/SiteBundle/Controller/AccountController.php
+++ b/src/BM2/SiteBundle/Controller/AccountController.php
@@ -584,6 +584,9 @@ class AccountController extends Controller {
 		if ($character->isAlive()) {
 			$character->setLastAccess(new \DateTime("now"));
 			$character->setSlumbering(false);
+			if ($character->getSystem('procd_inactive') {
+				$character->setSystem(NULL);
+			}
 			$em->flush();
 			if ($character->getSpecial()) {
 				// special menu active - check for reasons

--- a/src/BM2/SiteBundle/Resources/config/doctrine/Character.orm.xml
+++ b/src/BM2/SiteBundle/Resources/config/doctrine/Character.orm.xml
@@ -7,6 +7,7 @@
 		<field name="version" type="integer" version="true"/>
 		<field name="name" type="string"/>
 		<field name="known_as" type="string" nullable="true"/>
+		<field name="system" type="string" nullable="true"/>
 		<field name="male" type="boolean"/>
 		<field name="alive" type="boolean"/>
 		<field name="generation" type="smallint"/>

--- a/src/BM2/SiteBundle/Service/GameRunner.php
+++ b/src/BM2/SiteBundle/Service/GameRunner.php
@@ -165,7 +165,8 @@ class GameRunner {
 		}
 
 		$this->logger->info("Checking for dead and slumbering characters that need sorting...");
-		$query = $this->em->createQuery('SELECT c FROM BM2SiteBundle:Character c WHERE (c.alive = false AND c.location IS NOT NULL) OR (c.alive = true and c.slumbering = true)');
+		$query = $this->em->createQuery('SELECT c FROM BM2SiteBundle:Character c WHERE (c.alive = false AND c.location IS NOT NULL AND c.system <> :system) OR (c.alive = true and c.slumbering = true AND c.system <> :system)');
+		$query->setParameter('system' = 'procd_inactive');
 		$result = $query->getResult();
 		if (count($result) > 0) {
 			$this->logger->info("Sorting the dead from the slumbering...");
@@ -247,6 +248,7 @@ class GameRunner {
 			if ($character->getEstates()) {
 				#TODO: Add logic for transfering estates after we add realm laws (so we can check if the realm allows inheriting estates.
 			}
+			$character->setSystem('procd_inactive');
 		}
 		foreach ($slumbered as $character) {		
 			$this->logger->info($character->getName().", ".$character->getId()." is under review, as slumbering.");	
@@ -302,6 +304,7 @@ class GameRunner {
 			if ($character->getEstates()) {
 				#TODO: Add logic for transfering estates after we add realm laws (so we can check if the realm allows inheriting estates.
 			}
+			$character->setSystem('procd_inactive');
 		}
 		if ($keeponslumbercount > 0) {
 			$this->logger->info("$keeponslumbercount positions kept on slumber!");


### PR DESCRIPTION
This will fix the game reporting, every turn, that a slumberered character holds a position.

It also optimizes that part of the code by 5-15 seconds overall even at minimal work required and also optimizes the bandit code (to make it not process at all if there aren't any left, which should happen *soon*.)